### PR TITLE
Fix Elasticsearch NotFound Error

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,9 @@ AllCops:
   Exclude:
     - 'spec/dummy/**/*'
     - 'vendor/bundle/**/*'
-  TargetRubyVersion: 2.1
+    - 'lib/generators/**/*'
+    - 'solidus_recommendations.gemspec'
+  TargetRubyVersion: 2.3
 
 # Sometimes I believe this reads better
 # This also causes spacing issues on multi-line fixes

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 source 'https://rubygems.org'
 
 gem 'solidus', github: 'solidusio/solidus'

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'bundler'
 
 Bundler::GemHelper.install_tasks

--- a/app/models/concerns/spree/indexable.rb
+++ b/app/models/concerns/spree/indexable.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Spree
   module Indexable
     extend ActiveSupport::Concern

--- a/app/models/concerns/spree/order/indexable.rb
+++ b/app/models/concerns/spree/order/indexable.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Spree
   class Order
     module Indexable

--- a/app/models/concerns/spree/product/recommendable.rb
+++ b/app/models/concerns/spree/product/recommendable.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Spree
   class Product
     module Recommendable

--- a/app/models/concerns/spree/user/indexable.rb
+++ b/app/models/concerns/spree/user/indexable.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Spree
   class User
     module Indexable
@@ -16,7 +17,7 @@ module Spree
 
       included do
         include Spree::Indexable
-        
+
         ##
         # Define Order mapping for Elasticserach index
         #

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -1,2 +1,3 @@
+# frozen_string_literal: true
 Spree::Order.include Spree::Callbackable
 Spree::Order.include Spree::Order::Indexable

--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -1,1 +1,2 @@
+# frozen_string_literal: true
 Spree::Product.include Spree::Product::Recommendable

--- a/app/models/spree/user_decorator.rb
+++ b/app/models/spree/user_decorator.rb
@@ -1,2 +1,3 @@
+# frozen_string_literal: true
 Spree.user_class.include Spree::Callbackable
 Spree.user_class.include Spree::User::Indexable

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Spree::Core::Engine.routes.draw do
   # Add your extension routes here
 end

--- a/lib/generators/solidus_recommendations/install/install_generator.rb
+++ b/lib/generators/solidus_recommendations/install/install_generator.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SolidusRecommendations
   module Generators
     class InstallGenerator < Rails::Generators::Base

--- a/lib/solidus_recommendations.rb
+++ b/lib/solidus_recommendations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'solidus_core'
 require 'elasticsearch/model'
 require 'solidus_recommendations/engine'

--- a/lib/solidus_recommendations/client.rb
+++ b/lib/solidus_recommendations/client.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SolidusRecommendations
   class Client
     ##

--- a/lib/solidus_recommendations/engine.rb
+++ b/lib/solidus_recommendations/engine.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SolidusRecommendations
   class Engine < Rails::Engine
     require 'spree/core'

--- a/lib/solidus_recommendations/errors.rb
+++ b/lib/solidus_recommendations/errors.rb
@@ -1,8 +1,8 @@
+# frozen_string_literal: true
 module SolidusRecommendations
   module Errors
     class Standard < StandardError
-      def initialize(msg = MESSAGES[self.class])
-      end
+      def initialize(msg = MESSAGES[self.class]); end
     end
 
     class NonSupportedIndex < Standard; end

--- a/lib/solidus_recommendations/factories.rb
+++ b/lib/solidus_recommendations/factories.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 FactoryGirl.define do
   # Define your Spree extensions Factories within this file to enable applications, and other extensions to use and override them.
   #

--- a/lib/solidus_recommendations/recommendable/base.rb
+++ b/lib/solidus_recommendations/recommendable/base.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SolidusRecommendations
   module Recommendable
     class Base

--- a/lib/solidus_recommendations/recommendable/products.rb
+++ b/lib/solidus_recommendations/recommendable/products.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SolidusRecommendations
   module Recommendable
     ##

--- a/lib/solidus_recommendations/version.rb
+++ b/lib/solidus_recommendations/version.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SolidusRecommendations
-  VERSION = '0.0.1'
+  VERSION = '0.0.2'
 end

--- a/spec/lib/solidus_recommendations/client_spec.rb
+++ b/spec/lib/solidus_recommendations/client_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe SolidusRecommendations::Client do

--- a/spec/lib/solidus_recommendations/recommendable/products/get_spec.rb
+++ b/spec/lib/solidus_recommendations/recommendable/products/get_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe SolidusRecommendations::Recommendable::Products do
@@ -15,8 +16,8 @@ describe SolidusRecommendations::Recommendable::Products do
     end
 
     context 'When product is nil' do
-      let (:product) { nil }
-      let (:invoked) { subject.get(product) }
+      let(:product) { nil }
+      let(:invoked) { subject.get(product) }
 
       it 'should return an empty array' do
         expect(invoked).to be_kind_of Array
@@ -25,7 +26,7 @@ describe SolidusRecommendations::Recommendable::Products do
     end
 
     context 'When product is an Object' do
-      let (:product) { create(:product) }
+      let(:product) { create(:product) }
 
       it "should use the object's id" do
         expect(subject).to receive(:user_index_significant_terms).with(product.id, anything).and_call_original

--- a/spec/lib/solidus_recommendations/recommendable/products_spec.rb
+++ b/spec/lib/solidus_recommendations/recommendable/products_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe SolidusRecommendations::Recommendable::Products do

--- a/spec/models/concerns/spree/callbackable_spec.rb
+++ b/spec/models/concerns/spree/callbackable_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+describe Spree::Callbackable do
+  let(:user) { create(:user) }
+  subject { user }
+
+  it { is_expected.to respond_to :index_document }
+  it { is_expected.to respond_to :update_document }
+  it { is_expected.to respond_to :delete_document }
+
+  context 'when creating' do
+    let(:user) { build(:user) }
+
+    it 'should index the document' do
+      expect(user.__elasticsearch__).to receive(:index_document).and_call_original
+      user.save
+    end
+  end
+
+  context 'when updating' do
+    context 'when document is indexed' do
+      it 'should update the document' do
+        expect(user.__elasticsearch__).to receive(:update_document).and_call_original
+        user.update(email: 'test@example.com')
+      end
+    end
+
+    context 'when document is NOT indexed' do
+      it 'is expected to index the document' do
+        user.delete_document
+        expect(user.__elasticsearch__).to receive(:index_document).and_call_original
+        expect { user.update_document }.to_not raise_error Elasticsearch::Transport::Transport::Errors::NotFound
+      end
+    end
+  end
+
+  context 'when deleting' do
+    context 'when document is indexed' do
+      it 'should delete the document' do
+        expect(user.__elasticsearch__).to receive(:delete_document).and_call_original
+        user.delete_document
+      end
+    end
+
+    context 'when document is NOT indexed' do
+      it 'should NOT raise Elasticsearch::Transport::Transport::Errors::NotFound' do
+        user.delete_document
+        expect { user.delete_document }.to_not raise_error Elasticsearch::Transport::Transport::Errors::NotFound
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Run Coverage report
 require 'simplecov'
 SimpleCov.start do


### PR DESCRIPTION
Elasticsearch::Transport::Transport::Errors::NotFound
The above error is thrown when a deletion is made in the database but
the row had not been indexed into the cluster.

Since we don't care if the document is indexed at deletion time, there
shouldn't be an error thrown.  Catch the error and raise a warning
when trying to delete from the cluster.

Fixes https://github.com/skukx/solidus_recommendations/issues/1